### PR TITLE
Add document updated listener subscription

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,5 +29,6 @@ declare module 'pdf_editor_aleon35_react_plugin' {
     splitPages: () => void;
     extractPages: () => void;
     selectedPages: number[];
+    onDocumentUpdated: (listener: (pdfData: Uint8Array) => void) => () => void;
   };
 }


### PR DESCRIPTION
## Summary
- add a document-updated postMessage bridge so SDK consumers can react to saved changes
- expose an onDocumentUpdated helper that manages subscription cleanup
- regenerate the type definitions and compiled bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59338dd788323a56a1280a57c8bab